### PR TITLE
changed tag cloud color range

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,5 +15,5 @@
 //= require turbolinks//
 // Required by Blacklight
 //= require blacklight/blacklight
-
 //= require sufia
+//= require tagcloud.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,5 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 //= require sufia
+//= stub sufia/tagcloud.js
 //= require tagcloud.js

--- a/app/assets/javascripts/tagcloud.js
+++ b/app/assets/javascripts/tagcloud.js
@@ -1,6 +1,6 @@
 Blacklight.onLoad(function () {
     /*
-     *  Customizing color range for GW Libraries
+     *  Customizing Tag Cloud color range for GW Libraries
      */
     $(".tagcloud").blacklightTagCloud({
         size: {start: 0.9, end: 2.5, unit: 'em'},

--- a/app/assets/javascripts/tagcloud.js
+++ b/app/assets/javascripts/tagcloud.js
@@ -1,0 +1,12 @@
+Blacklight.onLoad(function () {
+    /*
+     *  Customizing color range for GW Libraries
+     */
+    $(".tagcloud").blacklightTagCloud({
+        size: {start: 0.9, end: 2.5, unit: 'em'},
+        cssHooks: {granularity: 15},
+        color: {start: '#004165', end: '#2971a7'}
+    });
+
+
+});


### PR DESCRIPTION
js customization file is in place at assets/javascripts/tagcloud.js and added to the manifest. The color range can be adjusted as needed. Currently using the darkest to lightest blue range for GW. 
Fixes #41  
