### PR TITLE
Creates Permanent Link: on item with dynamic URL generation.

### DIFF
--- a/app/views/generic_files/_show_descriptions.html.erb
+++ b/app/views/generic_files/_show_descriptions.html.erb
@@ -1,0 +1,9 @@
+<h2>Descriptions</h2>
+<dl class="dl-horizontal file-show-term file-show-descriptions">
+  <% present_terms(@presenter,@presenter.terms - [:title, :description]) do |r, term| %>
+  <dt><%= r.label(term) %></dt>
+      <dd><%= r.value(term) %></dd>
+  <% end %>
+  <dt>Permanent Link</dt>
+      <dd><%= link_to sufia.generic_file_url, sufia.generic_file_path(@generic_file) %></dd>
+</dl>


### PR DESCRIPTION
Addresses a metadata like request raised in SC meeting today.  No longer what to have citation as an editable metadata field, instead prefer to highlight permanent URL.
