### PR TITLE
T79 missing image assets

### DIFF
--- a/app/assets/stylesheets/gwcustom.scss
+++ b/app/assets/stylesheets/gwcustom.scss
@@ -65,7 +65,7 @@ $banner-blue-light: #2971a7;
 
 /* custom splash image */
 #home_header {
-  background-image: url(/assets/gw-scholarspace-1.jpg);
+  background-image: image-url('gw-scholarspace-1.jpg');
   background-position: 0% 0%;
   background-repeat: no-repeat;
   background-size: cover;

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,3 +1,4 @@
-<a id="logo" href="/"><img src="/assets/gw_iddol_libraries_wht_rev.png"></a><a href="/" class="institution_name"><%=t('sufia.product_name') %></a>
-
-
+<a id="logo" href="http://library.gwu.edu"><%= image_tag 'gw_iddol_libraries_wht_rev.png' %></a>
+<span class="logo">
+<a href="/" class="institution_name"><%= t('sufia.product_name') %></a>
+</span>


### PR DESCRIPTION
Resolves missing image assets when running:

```
bundle exec rake assets:precompile RAILS_ENV=production
```
