### PR TITLE
Added partial for gw_affiliation. Fixes #134

### DIFF
--- a/app/views/records/show_fields/_gw_affiliation.html.erb
+++ b/app/views/records/show_fields/_gw_affiliation.html.erb
@@ -1,0 +1,3 @@
+<% record.gw_affiliation.each do |gwaff| %>
+  <%= link_to_facet(gwaff, Solrizer.solr_name("gw_affiliation", :facetable)) %><br />
+<% end %>


### PR DESCRIPTION
To test: View an individual item's page.  In the "Descriptions" section, verify that the GW Unit value(s) is clickable, and that the link leads to the faceted search results view for items that include that GW Unit value.
