### PR TITLE
Applied catalog_controller patch advised by hydra-tech list. Fixes #193.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -20,11 +20,11 @@ class CatalogController < ApplicationController
   skip_before_filter :default_html_head
 
   def self.uploaded_field
-    solr_name('date_uploaded', :stored_sortable, type: :date)
+    solr_name('system_create', :stored_sortable, type: :date)
   end
 
   def self.modified_field
-    solr_name('date_modified', :stored_sortable, type: :date)
+    solr_name('system_modified', :stored_sortable, type: :date)
   end
 
   configure_blacklight do |config|          config.view.gallery.partials = [:index_header, :index]


### PR DESCRIPTION
`catalog_controller.rb` is created by a generator, so this needs to be fixed manually (at least in Sufia 6)
